### PR TITLE
feature: include existing tags from server in tag suggestions

### DIFF
--- a/src/config/index.tsx
+++ b/src/config/index.tsx
@@ -1,5 +1,5 @@
 import { Crud, Association } from '../utils/restful-resource-utility';
-import { Video, Segment } from '../types';
+import { Video, Segment, Tag, User, Group, Permission, Role } from '../types';
 
 export default {
   // serverURI: 'http://localhost:8080',
@@ -108,31 +108,31 @@ export const resources = {
 export type Repository = {
   install: (...args: any) => any;
   auditLog: Crud<any>;
-  user: Crud<any> & {
-    groups: Association<any>;
-    permissions: Association<any>;
-    segments: Association<any>;
+  user: Crud<User> & {
+    groups: Association<Group>;
+    permissions: Association<Permission>;
+    segments: Association<Segment>;
   };
   video: Crud<Video> & {
     segments: Association<Segment>;
   };
-  segment: Crud<any> & {
-    tags: Association<any>;
+  segment: Crud<Segment> & {
+    tags: Association<Tag>;
   };
-  tag: Crud<any>;
+  tag: Crud<Tag>;
   visitor: Crud<any>;
-  role: Crud<any> & {
-    users: Association<any>;
-    permissions: Association<any>;
+  role: Crud<Role> & {
+    users: Association<User>;
+    permissions: Association<Permission>;
   };
-  group: Crud<any> & {
-    users: Association<any>;
-    permissions: Association<any>;
+  group: Crud<Group> & {
+    users: Association<User>;
+    permissions: Association<Permission>;
   };
-  permissions: Crud<any> & {
-    users: Association<any>;
-    roles: Association<any>;
-    groups: Association<any>;
+  permissions: Crud<Permission> & {
+    users: Association<User>;
+    roles: Association<Role>;
+    groups: Association<Group>;
   };
 };
 

--- a/src/types/model/tag.type.ts
+++ b/src/types/model/tag.type.ts
@@ -3,8 +3,14 @@
  * but rather the structure of the data returned by the backend (sometimes formatted
  * for optimal use in the frontend).
  */
+import { Segment } from 'types';
 
 export type Tag = {
   _id?: string;
   name: string;
+  segments?: Segment[] | TagSegment[];
+};
+
+export type TagSegment = {
+  segment: Segment;
 };

--- a/src/utils/restful-resource-utility.tsx
+++ b/src/utils/restful-resource-utility.tsx
@@ -6,11 +6,13 @@ export type Logger = typeof console;
 export type Params = {
   [key: string]: any;
   $embed?: string | [string];
+  $term?: string;
+  $limit?: number;
 };
 
 export type ListResponse<T> = {
   data: {
-    docs: [T];
+    docs: T[];
   };
 };
 


### PR DESCRIPTION
As a quick update I added the existing server tags to the list of suggestions.

This gives a nice simple example of how we can include server data into components.